### PR TITLE
chore: gitignore x64/ 무시하도록 변경 (#30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,12 @@ dkms.conf
 
 # .vs 무시
 .vs/
+
+# log 무시
+*.tlog
+*.log
+*.tlog/
+
+#debug 무시
+x64/
+Debug/


### PR DESCRIPTION
# 🚀 gitignore x64/ 무시하도록 변경

## 📌 관련 이슈
Closes #30

## ✨ 변경 사항 요약
- gitignore 파일이 x64 폴더 내부 파일까지 모두 무시하도록 변경했습니다.
- 이제 .log와 .tlog는 모두 같이 무시됩니다.

## 🧪 테스트 방법
- [x] 빌드가 정상적으로 되는지 확인
- [x] 해당 기능이 예상대로 동작하는지 확인
- [x] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- `.gitignore`
(또는 해당 파일들)

## 📸 스크린샷 / 결과 (옵션)
- ![image](https://github.com/user-attachments/assets/fd5bb460-66e4-4432-bd38-67380f750d5a)

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
