### PR TITLE
feat: 게임 시작 화면 구현 (#24)

### DIFF
--- a/MeteorDodgeGamewithShooting/MeteorDodgeGamewithShooting.vcxproj
+++ b/MeteorDodgeGamewithShooting/MeteorDodgeGamewithShooting.vcxproj
@@ -135,7 +135,14 @@
   <ItemGroup>
     <ClCompile Include="bullet.c" />
     <ClCompile Include="game.c" />
-    <ClCompile Include="main.c" />
+    <ClCompile Include="main-복사.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="main.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="meteor.c" />
     <ClCompile Include="player.c" />
   </ItemGroup>

--- a/MeteorDodgeGamewithShooting/MeteorDodgeGamewithShooting.vcxproj.filters
+++ b/MeteorDodgeGamewithShooting/MeteorDodgeGamewithShooting.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="game.c">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="main-복사.c">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="game.h">

--- a/MeteorDodgeGamewithShooting/game.c
+++ b/MeteorDodgeGamewithShooting/game.c
@@ -3,11 +3,11 @@
 
 void DrawUI(Player player, int score, bool gameOver, bool gameStarted, int selectedMenu, const char** menuItems, int menuCount) {
     if (!gameStarted) {
-        DrawText("Meteor Dodge Game", 205, 100, 40, WHITE);
-        DrawText("with Shooting", 260, 140, 40, WHITE);
+        DrawText("Meteor Dodge Game", 405, 200, 40, WHITE);
+        DrawText("with Shooting", 460, 240, 40, WHITE);
         for (int i = 0; i < menuCount; i++) {
             Color color = (i == selectedMenu) ? ORANGE : WHITE;
-            DrawText(menuItems[i], 340, 250 + i * 40, 30, color);
+            DrawText(menuItems[i], 540, 350 + i * 40, 30, color);
         }
     }
     else {
@@ -16,9 +16,9 @@ void DrawUI(Player player, int score, bool gameOver, bool gameStarted, int selec
 
         if (gameOver) {
             DrawRectangle(0, 0, 800, 600, Fade(BLACK, 0.75f));
-            DrawText("GAME OVER", 260, 260, 40, RED);
-            DrawText("Press ENTER to restart", 250, 310, 20, LIGHTGRAY);
-            DrawText("Press BACKSPACE to Main", 245, 340, 20, LIGHTGRAY);
+            DrawText("GAME OVER", 460, 360, 40, RED);
+            DrawText("Press ENTER to restart", 450, 410, 20, LIGHTGRAY);
+            DrawText("Press BACKSPACE to Main", 445, 440, 20, LIGHTGRAY);
         }
     }
 }

--- a/MeteorDodgeGamewithShooting/game.c
+++ b/MeteorDodgeGamewithShooting/game.c
@@ -1,7 +1,25 @@
 #include "game.h"
+#include "player.h"
 
-void DrawUI(int score, int lives) {
-	 DrawText(TextFormat("score: %d",score), 10, 10, 20, WHITE);
-	 DrawText(TextFormat("lives: %d", lives), 10, 30, 20, WHITE);
+void DrawUI(Player player, int score, bool gameOver, bool gameStarted, int selectedMenu, const char** menuItems, int menuCount) {
+    if (!gameStarted) {
+        DrawText("Meteor Dodge Game", 205, 100, 40, WHITE);
+        DrawText("with Shooting", 260, 140, 40, WHITE);
+        for (int i = 0; i < menuCount; i++) {
+            Color color = (i == selectedMenu) ? ORANGE : WHITE;
+            DrawText(menuItems[i], 340, 250 + i * 40, 30, color);
+        }
+    }
+    else {
+        DrawText(TextFormat("Lives: %d", player.lives), 10, 10, 20, WHITE);
+        DrawText(TextFormat("Score: %d", score), 10, 35, 20, YELLOW);
+
+        if (gameOver) {
+            DrawRectangle(0, 0, 800, 600, Fade(BLACK, 0.75f));
+            DrawText("GAME OVER", 260, 260, 40, RED);
+            DrawText("Press ENTER to restart", 250, 310, 20, LIGHTGRAY);
+            DrawText("Press BACKSPACE to Main", 245, 340, 20, LIGHTGRAY);
+        }
+    }
 }
 

--- a/MeteorDodgeGamewithShooting/game.h
+++ b/MeteorDodgeGamewithShooting/game.h
@@ -1,5 +1,6 @@
 #include "raylib.h"
+#include "player.h"
 #define SCREEN_WIDTH 1200  
 #define SCREEN_HEIGHT 800
 
-void DrawUI(int score, int lives);
+void DrawUI(Player player, int score, bool gameOver, bool gameStarted, int selectedMenu, const char** menuItems, int menuCount);

--- a/MeteorDodgeGamewithShooting/main-복사.c
+++ b/MeteorDodgeGamewithShooting/main-복사.c
@@ -6,7 +6,7 @@
 
 int main(void)
 {
-    InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Hello Raylib!");
+    InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Meteor Dodge Game With Shooting");
     SetTargetFPS(60);
 
     Player player;

--- a/MeteorDodgeGamewithShooting/main-복사.c
+++ b/MeteorDodgeGamewithShooting/main-복사.c
@@ -62,8 +62,8 @@ int main(void)
                         BeginDrawing();
                         ClearBackground(BLACK);
                         // 최고점수 보여주기
-                        DrawText(TextFormat("High Score: %d", highScore), 280, 260, 30, YELLOW);
-                        DrawText("Press ENTER to return", 230, 320, 20, LIGHTGRAY);
+                        DrawText(TextFormat("High Score: %d", highScore), 450, 360, 30, YELLOW);
+                        DrawText("Press ENTER to return", 430, 420, 20, LIGHTGRAY);
                         EndDrawing();
                         // 엔터 치면 이전 메뉴로 돌아가기
                         if (IsKeyPressed(KEY_ENTER)) break;
@@ -74,12 +74,12 @@ int main(void)
                     while (!WindowShouldClose()) {
                         BeginDrawing();
                         ClearBackground(BLACK);
-                        DrawText("Created by Team", 230, 200, 30, YELLOW);
-                        DrawText("22011848 Shin Hyewon", 260, 250, 20, WHITE);
-                        DrawText("21011777 Im Wookyun", 260, 270, 20, WHITE);
-                        DrawText("22011796 Woo Jiwon", 260, 290, 20, WHITE);
-                        DrawText("22011813 Cha Seoyeung", 260, 310, 20, WHITE);
-                        DrawText("Press ENTER to return", 260, 400, 20, LIGHTGRAY);
+                        DrawText("Created by Team", 430, 300, 30, YELLOW);
+                        DrawText("22011848 Shin Hyewon", 430, 350, 20, WHITE);
+                        DrawText("21011777 Im Wookyun", 430, 370, 20, WHITE);
+                        DrawText("22011796 Woo Jiwon", 430, 390, 20, WHITE);
+                        DrawText("22011813 Cha Seoyeung", 430, 410, 20, WHITE);
+                        DrawText("Press ENTER to return", 430, 460, 20, LIGHTGRAY);
                         EndDrawing();
                         if (IsKeyPressed(KEY_ENTER)) break;
                     }

--- a/MeteorDodgeGamewithShooting/main-복사.c
+++ b/MeteorDodgeGamewithShooting/main-복사.c
@@ -1,0 +1,113 @@
+#include "raylib.h"
+#include "game.h"
+#include "player.h"
+#include "meteor.h"
+#include "bullet.h"
+
+int main(void)
+{
+    InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Hello Raylib!");
+    SetTargetFPS(60);
+
+    Player player;
+    InitPlayer(&player);
+
+    Meteor meteors[MAX_METEORS];
+    InitMeteors();
+
+    Bullet bullets[MAX_BULLETS] = { 0 };
+
+    bool gameStarted = false;
+    bool gameOver = false;
+    int selectedMenu = 0;
+    const char* menuItems[] = { "Start", "Score", "Credits", "Exit" };
+    const int menuCount = 4;
+
+    int score = 0;
+    int highScore = 0;  // 전역변수로 관리 필요, meteor.c에서부터 정의를 넣는 게 좋을듯
+
+    while (!WindowShouldClose())
+    {
+        if (gameStarted && IsKeyPressed(KEY_BACKSPACE)) {
+            gameStarted = false;
+            continue;
+        }
+        //게임 시작 전
+        if (!gameStarted) {     
+            BeginDrawing();
+            ClearBackground(BLACK);
+            DrawUI(player, score, gameOver, gameStarted, selectedMenu, menuItems, menuCount);
+            EndDrawing();
+
+            if (IsKeyPressed(KEY_DOWN)) selectedMenu = (selectedMenu + 1) % menuCount;
+            else if (IsKeyPressed(KEY_UP)) selectedMenu = (selectedMenu - 1 + menuCount) % menuCount;
+            // 메뉴 중 하나를 고른 경우
+            else if (IsKeyPressed(KEY_ENTER)) {
+                // Start 버튼 Enter
+                if (selectedMenu == 0) {
+                    // 게임 시작 상황
+                    gameStarted = true;
+                    // 플레이어 초기화
+                    InitPlayer(&player);
+                    // 운석 초기화
+                    InitMeteors();
+                    // 총알 전부 비활성화
+                    for (int i = 0; i < MAX_BULLETS; i++) bullets[i].active = false;
+                    // 총알 쿨타임, 점수, 점수에 따른 운석 속도 초기화 (=0) 필요
+                    gameOver = false;
+                }
+                // Score 버튼 엔터
+                else if (selectedMenu == 1) {
+                    while (!WindowShouldClose()) {
+                        BeginDrawing();
+                        ClearBackground(BLACK);
+                        // 최고점수 보여주기
+                        DrawText(TextFormat("High Score: %d", highScore), 280, 260, 30, YELLOW);
+                        DrawText("Press ENTER to return", 230, 320, 20, LIGHTGRAY);
+                        EndDrawing();
+                        // 엔터 치면 이전 메뉴로 돌아가기
+                        if (IsKeyPressed(KEY_ENTER)) break;
+                    }
+                }
+                // Credits 버튼 엔터
+                else if (selectedMenu == 2) {
+                    while (!WindowShouldClose()) {
+                        BeginDrawing();
+                        ClearBackground(BLACK);
+                        DrawText("Created by Team", 230, 200, 30, YELLOW);
+                        DrawText("22011848 Shin Hyewon", 260, 250, 20, WHITE);
+                        DrawText("21011777 Im Wookyun", 260, 270, 20, WHITE);
+                        DrawText("22011796 Woo Jiwon", 260, 290, 20, WHITE);
+                        DrawText("22011813 Cha Seoyeung", 260, 310, 20, WHITE);
+                        DrawText("Press ENTER to return", 260, 400, 20, LIGHTGRAY);
+                        EndDrawing();
+                        if (IsKeyPressed(KEY_ENTER)) break;
+                    }
+                }
+                //Exit 버튼 엔터
+                else if (selectedMenu == 3) {
+                    CloseWindow();
+                    return 0;
+                }
+            }
+            continue;
+        }
+        // 게임은 시작이 됐고, game over 는 아닐 경우
+        if (!gameOver) {
+            // update 함수들이 들어갈 예정
+            // 총알 발사도 이쪽에서 구현
+            // 게임 오버 후 엔터 입력하면 재시작
+        }
+
+        BeginDrawing();
+        ClearBackground(BLACK);
+        DrawPlayer();
+        DrawMeteors();
+        DrawBullets();
+        DrawUI(player, score, gameOver, gameStarted, selectedMenu, menuItems, menuCount);
+        EndDrawing();
+    }
+
+    CloseWindow();
+    return 0;
+}


### PR DESCRIPTION
# 🚀 Pull Request 제목
게임 시작 화면 구현 (#24)

## 📌 관련 이슈
Closes #24 

## ✨ 변경 사항 요약
- 게임 시작 화면 구성 (Start, Score, Credits, Exit 버튼 구현)
- game의 DrawUI 함수 수정
- main.c를 수정하면 이후 develop에 수정된 main.c가 팀원들에게 병합될 것 같아 main-복사.c 생성 후 수정
- 텍스트가 윈도우 창의 중심에 오도록 position 수정
- 윈도우 창 제목 수정 (Meteor Dodge Game with Shooting)

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- `game.c`
- `game.h`
- `main-복사.c` <- 생성

## 📸 스크린샷 / 결과 (옵션)

https://github.com/user-attachments/assets/248cc599-9413-43d8-8ae9-138d4aab109a


## 🙏 리뷰어에게
- main-복사.c가 생성되었습니다. 팀원 분들은 모두 main.c를 이용해주세요. (스테이징은 하지 말아주세요!)
- main.c 자체를 변경하는 코드는 main-복사.c에 작성하도록 하겠습니다.
- 참고로 개발하실 때는 main-복사.c를 빌드에서 제외 해두고 개발하시면 되겠습니다.
- (main-복사.c 소스파일 오른쪽 클릭 -> 속성 -> 빌드에서 제외 -> 예 하시면 Ctrl+F5 하실때 문제없이 실행 가능합니다.)

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
