### PR TITLE
운석 화면 이탈 시 재생성 (#18)

### DIFF
--- a/MeteorDodgeGamewithShooting/meteor.c
+++ b/MeteorDodgeGamewithShooting/meteor.c
@@ -5,11 +5,9 @@ static Color meteorColors[MAX_METEORS];
 #define minBright 100
 
 // 무작위 운석 생성 함수
-static Meteor CreateRandomMeteor(int index) {
-    Meteor m;
-
-    // 반지름: 10~40
-    m.radius = (float)(rand() % 31 + 10);
+static void RepawnMeteor(int index) {
+    float radius = (float)(rand() % 31 + 10);
+    meteors[index].radius = radius;
 
     // 무작위 색상 저장(밝게)
     meteorColors[index] = (Color){
@@ -23,18 +21,19 @@ static Meteor CreateRandomMeteor(int index) {
     int edge = rand() % 4;
     switch (edge) {
     case 0: // Top
-        m.position = (Vector2){ rand() % SCREEN_WIDTH, -m.radius };
+        meteors[index].position = (Vector2){ rand() % SCREEN_WIDTH, -radius };
         break;
     case 1: // Bottom
-        m.position = (Vector2){ rand() % SCREEN_WIDTH, SCREEN_HEIGHT + m.radius };
+        meteors[index].position = (Vector2){ rand() % SCREEN_WIDTH, SCREEN_HEIGHT + radius };
         break;
     case 2: // Left
-        m.position = (Vector2){ -m.radius, rand() % SCREEN_HEIGHT };
+        meteors[index].position = (Vector2){ -radius, rand() % SCREEN_HEIGHT };
         break;
     case 3: // Right
-        m.position = (Vector2){ SCREEN_WIDTH + m.radius, rand() % SCREEN_HEIGHT };
+        meteors[index].position = (Vector2){ SCREEN_WIDTH + radius, rand() % SCREEN_HEIGHT };
         break;
     }
+
 
     //화면 외부에서 내부로 랜덤한 방향
     float angle = ((float)(rand() % 360)) * DEG2RAD;
@@ -43,18 +42,17 @@ static Meteor CreateRandomMeteor(int index) {
         sinf(angle)
     };
 
-    // 속도
+    //속도
     float speed = 5;
-    m.velocity = (Vector2){ direction.x * speed, direction.y * speed };
-
-    return m;
+    meteors[index].velocity = (Vector2){direction.x * speed, direction.y * speed};
 }
+
 
 // 운석 초기화
 void InitMeteors() {
     srand((unsigned int)time(NULL));
     for (int i = 0; i < MAX_METEORS; i++) {
-        meteors[i] = CreateRandomMeteor(i);
+        RepawnMeteor(i);
     }
 }
 
@@ -64,10 +62,9 @@ void UpdateMeteors() {
         meteors[i].position.x += meteors[i].velocity.x;
         meteors[i].position.y += meteors[i].velocity.y;
 
-        // 화면을 벗어나면 다시 생성
         if (meteors[i].position.x < -100 || meteors[i].position.x > SCREEN_WIDTH + 100 ||
             meteors[i].position.y < -100 || meteors[i].position.y > SCREEN_HEIGHT + 100) {
-            meteors[i] = CreateRandomMeteor(i);
+            RepawnMeteor(i);  // 기존 meteor 재사용
         }
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request 제목
운석 화면 이탈 시 재생성 (#18)

## 📌 관련 이슈
Closes #18 

## ✨ 변경 사항 요약
- 운석이 화면 이탈 시 새로 만들어지는 것에서 재사용되는 것으로 변경(meteor.c)

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- MeteorDodgeGamewithShooting/meteor.c

## 📸 스크린샷 / 결과 (옵션)
https://github.com/user-attachments/assets/3bbc11db-919e-415e-8114-133d89810309


## 🙏 리뷰어에게
- main-복사.c파일 말고 아래의 코드를 main.c파일에 적용하여 빌드해야 동작합니다. 해당 코드는 Issue#17 PullRequest 문서에 적은 코드와 동일합니다.

#include "raylib.h"
#include "game.h"
#include "meteor.h"

int main(void)
{
    InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Hello Raylib!");
    SetTargetFPS(60);

    InitMeteors();

    while (!WindowShouldClose())
    {
        UpdateMeteors();

        BeginDrawing();
        ClearBackground(BLACK);

        DrawMeteors();

        EndDrawing();
    }

    CloseWindow();
    return 0;
}

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
