### PR TITLE
refactor: 운석 및 플레이어, 총알 충돌 시 Distance 대신 Collision 함수 사용 (#56)

### DIFF
--- a/MeteorDodgeGamewithShooting/meteor.c
+++ b/MeteorDodgeGamewithShooting/meteor.c
@@ -72,8 +72,8 @@ void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets) {
         if (!bullets[i].active) continue;
 
         for (int j = 0; j < MAX_METEORS; j++) {
-            float dist = Vector2Distance(bullets[i].position, meteors[j].position);
-            if (dist < meteors[j].radius + BULLET_RADIUS) {
+            if (CheckCollisionCircles(bullets[i].position, BULLET_RADIUS,
+                meteors[j].position, meteors[j].radius)) {
                 bullets[i].active = false;
                 RespawnMeteor(&meteors[j], j);
                 break;
@@ -90,8 +90,8 @@ void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets) {
 
     //운석-플레이어 충돌 처리: 19
     for (int i = 0; i < MAX_METEORS; i++) {
-        float dist = Vector2Distance(playerRef->position, meteors[i].position);
-        if (dist < meteors[i].radius + PLAYER_SIZE / 2.0f) {
+        if (CheckCollisionCircles(playerRef->position, PLAYER_SIZE / 2.0f,
+            meteors[i].position, meteors[i].radius)) {
             playerCollision(playerRef);
             playerRef->lives--;
             break;


### PR DESCRIPTION
# 🚀 Pull Request 제목
refactor: 운석 및 플레이어, 총알 충돌 시 Distance 대신 Collision 함수 사용 (#56)

## 📌 관련 이슈
Closes #56 

## ✨ 변경 사항 요약
- 운석-플레이어, 운석-총알 충돌 시 Vector2Distance 함수 대신 CheckCollisionCircles함수를 사용하도록 변경(meteor.c)

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- MeteorDodgeGamewithShooting/meteor.c

## 📸 스크린샷 / 결과 (옵션)
https://github.com/user-attachments/assets/e99fe00e-4184-4f74-bbf1-6a321174c742


## 🙏 리뷰어에게
- 함수만 변경하여 main이나 bullet, player관련 코드들 변경 없습니다. 

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
