### PR TITLE
refactor: 운석 색상 값 구조체에 저장 (#59)

### DIFF
--- a/MeteorDodgeGamewithShooting/meteor.c
+++ b/MeteorDodgeGamewithShooting/meteor.c
@@ -3,15 +3,12 @@
 #include "game.h"
 
 
-static Color meteorColors[MAX_METEORS];
-#define minBright 100
-
 // 무작위 운석 생성 함수
 static void RespawnMeteor(Meteor* m, int index) {
     m->radius = (float)(rand() % 31 + 10);
 
     // 무작위 색상 저장(밝게)
-    meteorColors[index] = (Color){
+    m->color = (Color){
     minBright + rand() % (256 - minBright),
     minBright + rand() % (256 - minBright),
     minBright + rand() % (256 - minBright),
@@ -76,7 +73,7 @@ void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets) {
         for (int j = 0; j < MAX_METEORS; j++) {
             if (CheckCollisionCircles(bullets[i].position, BULLET_RADIUS,
                 meteors[j].position, meteors[j].radius)) {
-                GenerateExplosion(meteors[j].position, GRAY);
+                GenerateExplosion(meteors[j].position, meteors[j].color);
                 bullets[i].active = false;
                 RespawnMeteor(&meteors[j], j);
                 break;
@@ -106,6 +103,6 @@ void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets) {
 // 운석 그리기
 void DrawMeteors(Meteor* meteors) {
     for (int i = 0; i < MAX_METEORS; i++) {
-        DrawCircleV(meteors[i].position, meteors[i].radius, meteorColors[i]);
+        DrawCircleV(meteors[i].position, meteors[i].radius, meteors[i].color);
     }
 }

--- a/MeteorDodgeGamewithShooting/meteor.h
+++ b/MeteorDodgeGamewithShooting/meteor.h
@@ -8,10 +8,12 @@
 #include <time.h>
 
 #define MAX_METEORS 40
+#define minBright 100
 
 typedef struct Meteor {
 	Vector2 position;
 	Vector2 velocity;
+	Color color;
 	float radius;
 }Meteor;
 


### PR DESCRIPTION
# 🚀 Pull Request 제목
refactor: 운석 색상 값 구조체에 저장 (#59)

## 📌 관련 이슈
Closes #59 

## ✨ 변경 사항 요약
- 운석 색상 값을 운석 구조체에 저장하도록 변경(meteor.h)
- 파편 함수가 해당 운석의 색상을 전달받도록 변경(meteor.c)

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- MeteorDodgeGamewithShooting/meteor.c
- MeteorDodgeGamewithShooting/meteor.h
(또는 해당 파일들)

## 📸 스크린샷 / 결과 (옵션)
https://github.com/user-attachments/assets/6af07567-cac0-408c-aa42-c4809a2da73d


## 🙏 리뷰어에게
- main-복사.c 변경사항 없습니다.
---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
