### PR TITLE
fix: 생명이 다 닳아도 게임오버가 안되는 현상 (#63)

### DIFF
--- a/MeteorDodgeGamewithShooting/main-복사.c
+++ b/MeteorDodgeGamewithShooting/main-복사.c
@@ -53,6 +53,8 @@ int main(void)
                     InitMeteors(meteors);
                     // 총알 전부 비활성화
                     for (int i = 0; i < MAX_BULLETS; i++) bullets[i].active = false;
+                    // 충돌 파티클 비활성화
+                    for (int i = 0; i < MAX_PARTICLES; i++) particles[i].active = false;
                     // 총알 쿨타임, 점수, 점수에 따른 운석 속도 초기화 (=0) 필요
                     score = 0;
                     gameOver = false;
@@ -98,7 +100,7 @@ int main(void)
             // 반복문 안에서 Update 함수 계속 호출
             UpdatePlayer(&player);
             UpdateBullets(bullets);
-            UpdateMeteors(meteors, &player, bullets, &score);
+            UpdateMeteors(meteors, &player, bullets, &score, &gameOver);
             UpdateParticles();
 
             if (IsKeyDown(KEY_SPACE)) {
@@ -115,6 +117,8 @@ int main(void)
             InitMeteors(meteors);
             // 총알 전부 비활성화
             for (int i = 0; i < MAX_BULLETS; i++) bullets[i].active = false;
+            // 충돌 파티클 비활성화
+            for (int i = 0; i < MAX_PARTICLES; i++) particles[i].active = false;
             // score 초기화
             score = 0;
             gameOver = false;

--- a/MeteorDodgeGamewithShooting/meteor.c
+++ b/MeteorDodgeGamewithShooting/meteor.c
@@ -56,7 +56,7 @@ void InitMeteors(Meteor* meteors) {
 }
 
 //운석 위치 업데이트-17
-void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets, int *score) {
+void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets, int *score, bool *gameOver) {
     for (int i = 0; i < MAX_METEORS; i++) {
         meteors[i].position.x += meteors[i].velocity.x;
         meteors[i].position.y += meteors[i].velocity.y;
@@ -100,6 +100,8 @@ void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets, int *sco
             GenerateExplosion(playerRef->position, RED);
             playerCollision(playerRef);
             playerRef->lives--;
+            // lives <= 0 이면 게임 오버
+            if (playerRef->lives <= 0) *gameOver = true;
             break;
         }
     }

--- a/MeteorDodgeGamewithShooting/meteor.h
+++ b/MeteorDodgeGamewithShooting/meteor.h
@@ -20,5 +20,5 @@ typedef struct Meteor {
 }Meteor;
 
 void InitMeteors(Meteor* meteors);
-void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets, int *score);
+void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets, int *score, bool *gameOver);
 void DrawMeteors(Meteor* meteors);


### PR DESCRIPTION
# 🚀 Pull Request 제목
생명이 다 닳아도 게임오버가 안되는 현상 (#63)

## 📌 관련 이슈
Closes #63 

## ✨ 변경 사항 요약
- 생명이 0 이하가 되면 gameOver = true로 변경
- UpdateMeteors에 매개변수 bool *gameOver 추가
- 재시작 시 충돌했을 때 발생하는 파티클이 그대로 남아있는 버그 발견해서 비활성화 코드 추가

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- `meteor.c`
- `meteor.h`
- `main-복사.c`

## 📸 스크린샷 / 결과 (옵션)

https://github.com/user-attachments/assets/28c89783-0087-48ff-bab7-101b40041a77


## 🙏 리뷰어에게
- `main-복사.c` 변경되었습니다.

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
