### PR TITLE
feat: 플레이어 트레일 효과 및 사망 시 이동 제한 (#11)

### DIFF
--- a/MeteorDodgeGamewithShooting/player.c
+++ b/MeteorDodgeGamewithShooting/player.c
@@ -5,105 +5,129 @@
 
 void InitPlayer(Player* playerRef) {
 
-	playerRef->position = (Vector2){ 600, 400 };  // 초기 위치
-	playerRef->velocity = (Vector2){ 0, 0 };      // 초기 속도
-	playerRef->head = (Vector2){ 0, 0 };
-	playerRef->angle = 0.0f;
-	playerRef->lives = 5;
-	playerRef->isCollision = false;
+    playerRef->position = (Vector2){ 600, 400 };  // 초기 위치
+    playerRef->velocity = (Vector2){ 0, 0 };      // 초기 속도
+    playerRef->head = (Vector2){ 0, 0 };
+    playerRef->angle = 0.0f;
+    playerRef->lives = 5;
+    playerRef->isCollision = false;
+    playerRef->trailIdx = 0;
 }
 
-void playerCollision(Player *playerRef) {
-	playerRef->position = (Vector2){ 600 , 400 };
-	playerRef->deathTime = GetTime();
-	playerRef->isCollision = true;
+void playerCollision(Player* playerRef) {
+    playerRef->position = (Vector2){ 600 , 400 };
+    playerRef->deathTime = GetTime();
+    playerRef->isCollision = true;
+    for (int i = 0; i < TRAIL_LENGTH; i++) {
+        playerRef->trail[i] = (Vector2){ 0, 0 };
+    }
+    playerRef->trailIdx = 0;
 }
 
 void DrawPlayer(Player* playerRef) {
-	float rad = playerRef->angle * (PI / 180.0f);
+    float rad = playerRef->angle * (PI / 180.0f);
 
-	// 플레이어가 바라보는 위치
-	playerRef->head.x = playerRef->position.x + PLAYER_SIZE * cos(rad);
-	playerRef->head.y = playerRef->position.y + PLAYER_SIZE * sin(rad);
+    // 플레이어가 바라보는 위치
+    playerRef->head.x = playerRef->position.x + PLAYER_SIZE * cos(rad);
+    playerRef->head.y = playerRef->position.y + PLAYER_SIZE * sin(rad);
 
-	// -90도 방향 (왼쪽)
-	float leftRad = (playerRef->angle - 90.0f) * (PI / 180.0f);
-	playerRef->left.x = playerRef->position.x + PLAYER_SIZE / 2 * cos(leftRad);
-	playerRef->left.y = playerRef->position.y + PLAYER_SIZE / 2 * sin(leftRad);
+    // -90도 방향 (왼쪽)
+    float leftRad = (playerRef->angle - 90.0f) * (PI / 180.0f);
+    playerRef->left.x = playerRef->position.x + PLAYER_SIZE / 2 * cos(leftRad);
+    playerRef->left.y = playerRef->position.y + PLAYER_SIZE / 2 * sin(leftRad);
 
-	// +90도 방향 (오른쪽)
-	float rightRad = (playerRef->angle + 90.0f) * (PI / 180.0f);
-	playerRef->right.x = playerRef->position.x + PLAYER_SIZE / 2 * cos(rightRad);
-	playerRef->right.y = playerRef->position.y + PLAYER_SIZE / 2 * sin(rightRad);
+    // +90도 방향 (오른쪽)
+    float rightRad = (playerRef->angle + 90.0f) * (PI / 180.0f);
+    playerRef->right.x = playerRef->position.x + PLAYER_SIZE / 2 * cos(rightRad);
+    playerRef->right.y = playerRef->position.y + PLAYER_SIZE / 2 * sin(rightRad);
 
 
-	//########## 플레이어 깜빡임 처리 #########//
-	
-	if (playerRef->isCollision == true) {
-		double diffTime = GetTime() - playerRef->deathTime;
-		if (diffTime < 2) {
-			if (fmod(diffTime, 0.4) < 0.2) {
-				DrawCircleV(playerRef->position, 5.0f, RED);
-				DrawTriangle(playerRef->head, playerRef->left, playerRef->right, RED);
-			}
-			else {
-			}
-		}
-		else {
-			playerRef->isCollision = false;
-		}
-		DrawText(TextFormat("%.2f", diffTime), 10, 10, 20, RED);
-	}
-	else {
-		DrawCircleV(playerRef->position, 5.0f, RED);
-		DrawTriangle(playerRef->head, playerRef->left, playerRef->right, RED);
-	}
+    //트레일 그리기
+    for (int i = 0; i < TRAIL_LENGTH; i++) {
+        int idx = (playerRef->trailIdx + i) % TRAIL_LENGTH;
+        float trace = (float)i / TRAIL_LENGTH;
+        Color fade = (Color){ 255,0,0 ,(unsigned char)(trace * 100) };
+        DrawCircleV(playerRef->trail[idx], 3.0f, fade);
+    }
+
+
+    //########## 플레이어 깜빡임 처리 #########//
+
+    if (playerRef->isCollision == true) {
+        double diffTime = GetTime() - playerRef->deathTime;
+        if (diffTime < 2) {
+            if (fmod(diffTime, 0.4) < 0.2) {
+                DrawCircleV(playerRef->position, 5.0f, RED);
+                DrawTriangle(playerRef->head, playerRef->left, playerRef->right, RED);
+            }
+            else {
+            }
+        }
+        else {
+            playerRef->isCollision = false;
+        }
+        DrawText(TextFormat("%.2f", diffTime), 10, 10, 20, RED);
+    }
+    else {
+        DrawCircleV(playerRef->position, 5.0f, RED);
+        DrawTriangle(playerRef->head, playerRef->left, playerRef->right, RED);
+    }
 }
 
 void UpdatePlayer(Player* playerRef) {
+    float deltaTime = GetFrameTime();
+    float rad = (PI / 180.0f);
+    float turnspeed = 360.0;
+    float maxspeed = 10.0f;
 
-	
-	//######### 속도/ 위치 업데이트 ###########//
+    // 죽고 1초간 조작 제한
+    bool canMove = true;
+    if (playerRef->isCollision) {
+        double diffTime = GetTime() - playerRef->deathTime;
+        if (diffTime < 1) {
+            canMove = false;
+        }
+    }
+    if (!canMove) {
+        playerRef->velocity = (Vector2){ 0, 0 };
+        return;
+    }
 
-	float deltaTime = GetFrameTime();
-	float rad = (PI / 180.0f);
-	float turnspeed = 360.0;
-	float maxspeed = 10.0f;
+    // 회전
+    if (IsKeyDown(KEY_LEFT))  playerRef->angle -= turnspeed * deltaTime;
+    if (IsKeyDown(KEY_RIGHT)) playerRef->angle += turnspeed * deltaTime;
 
-	// 플레이어 회전
-	if (IsKeyDown(KEY_LEFT))  playerRef->angle -= turnspeed * deltaTime;
-	if (IsKeyDown(KEY_RIGHT)) playerRef->angle += turnspeed * deltaTime;
+    // 속도 증가
+    float acceleration = 0.0f;
+    if (IsKeyDown(KEY_UP)) {
+        acceleration = PLAYER_ACCEL;
+    }
+    else {
+        playerRef->velocity.x *= PLAYER_FRICTION;
+        playerRef->velocity.y *= PLAYER_FRICTION;
+    }
 
-	// 속도 증가
-	float acceleration = 0.0f;
-	if (IsKeyDown(KEY_UP)) {
-		acceleration = PLAYER_ACCEL;
-	}
-	else {
-		// 감속
-		playerRef->velocity.x *= PLAYER_FRICTION;
-		playerRef->velocity.y *= PLAYER_FRICTION;
-	}
+    // 방향 계산
+    Vector2 direction = {
+        cosf(playerRef->angle * rad),
+        sinf(playerRef->angle * rad)
+    };
 
-	// 바라보는 방향으로 속도 적용
-	Vector2 direction = {
-		cosf(playerRef->angle * rad),
-		sinf(playerRef->angle * rad)
-	};
+    // 속도 업데이트
+    playerRef->velocity.x += direction.x * acceleration;
+    playerRef->velocity.y += direction.y * acceleration;
 
-	//속도 업데이트
-	playerRef->velocity.x += direction.x * acceleration;
-	playerRef->velocity.y += direction.y * acceleration;
+    // 속도 제한
+    float speed = Vector2Length(playerRef->velocity);
+    if (speed > maxspeed) {
+        playerRef->velocity = Vector2Scale(Vector2Normalize(playerRef->velocity), maxspeed);
+    }
 
-	// 속도 제한
-	float speed = Vector2Length(playerRef->velocity);
-	if (speed > maxspeed) {
-		playerRef->velocity = Vector2Scale(Vector2Normalize(playerRef->velocity), maxspeed);
-	}
+    // 위치 업데이트
+    playerRef->position.x += playerRef->velocity.x;
+    playerRef->position.y += playerRef->velocity.y;
 
-	// 위치 업데이트
-	playerRef->position.x += playerRef->velocity.x;
-	playerRef->position.y += playerRef->velocity.y;
-
+    //트레일 위치 저장
+    playerRef->trail[playerRef->trailIdx] = playerRef->position;
+    playerRef->trailIdx = (playerRef->trailIdx + 1) % TRAIL_LENGTH;
 }
-

--- a/MeteorDodgeGamewithShooting/player.c
+++ b/MeteorDodgeGamewithShooting/player.c
@@ -47,7 +47,7 @@ void DrawPlayer(Player* playerRef) {
         int idx = (playerRef->trailIdx + i) % TRAIL_LENGTH;
         float trace = (float)i / TRAIL_LENGTH;
         Color fade = (Color){ 255,0,0 ,(unsigned char)(trace * 100) };
-        DrawCircleV(playerRef->trail[idx], 3.0f, fade);
+        DrawCircleV(playerRef->trail[idx], 4.0f, fade);
     }
 
 

--- a/MeteorDodgeGamewithShooting/player.h
+++ b/MeteorDodgeGamewithShooting/player.h
@@ -13,6 +13,8 @@
 struct Player
 {
 	Vector2 position;
+
+	Vector2 trail[TRAIL_LENGTH];
 	Vector2 velocity;
 	Vector2 head,left,right;
 	bool isCollision;
@@ -20,6 +22,7 @@ struct Player
 	float angle;
 	float size;
 	int lives;
+	int trailIdx;
 }typedef Player;
 
 void InitPlayer(Player *playerRef);


### PR DESCRIPTION
# 🚀 Pull Request 제목
플레이어 트레일 효과 및 사망 시 이동제한 구현 (#11)

## 📌 관련 이슈
Closes #11 

## ✨ 변경 사항 요약
- 플레이어 이동 시 트레일 효과 구현
- 플레이어 사망 시 1초 동안 이동 제한
- player.c

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- MeteorDodgeGamewithShooting/player.h
- MeteorDodgeGamewithShooting/player.c


## 📸 스크린샷 / 결과 (옵션)




https://github.com/user-attachments/assets/652c69ae-098d-437e-b874-d4a5d0e17ed1






## 🙏 리뷰어에게
- canMove 변수로 사망 시 1초 동안 이동제한 구현했습니다. 시간은 조정 가능합니다.
- 트레일 효과는 사망시 화면에 남은 잔상은 바로 삭제되게 구현했습니다.

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
