### PR TITLE
점수에 따라 운석의 속력 증가 구현 (#27)

### DIFF
--- a/MeteorDodgeGamewithShooting/MeteorDodgeGamewithShooting.vcxproj
+++ b/MeteorDodgeGamewithShooting/MeteorDodgeGamewithShooting.vcxproj
@@ -135,10 +135,6 @@
   <ItemGroup>
     <ClCompile Include="bullet.c" />
     <ClCompile Include="game.c" />
-    <ClCompile Include="main-복사.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="main.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>

--- a/MeteorDodgeGamewithShooting/meteor.c
+++ b/MeteorDodgeGamewithShooting/meteor.c
@@ -3,6 +3,8 @@
 #include "game.h"
 
 int highScore = 0;
+int checkScore = 0;
+float speed;
 
 // 무작위 운석 생성 함수
 static void RespawnMeteor(Meteor* m, int index) {
@@ -42,7 +44,6 @@ static void RespawnMeteor(Meteor* m, int index) {
     };
 
     //속도
-    float speed = 3;
     m->velocity = (Vector2){ direction.x * speed, direction.y * speed };
 }
 
@@ -50,6 +51,7 @@ static void RespawnMeteor(Meteor* m, int index) {
 // 운석 초기화
 void InitMeteors(Meteor* meteors) {
     srand((unsigned int)time(NULL));
+    speed = 3;
     for (int i = 0; i < MAX_METEORS; i++) {
         RespawnMeteor(&meteors[i], i);
     }
@@ -78,6 +80,13 @@ void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets, int *sco
                 bullets[i].active = false;
                 // 총알과 운석이 충돌했을 경우 점수 100점 추가
                 *score += 100;
+                checkScore += 100;
+                //1000점 획득 할 때마다 속도 +0.5f
+                if (checkScore / 1000 == 1) 
+                {
+                    speed += 0.5f;
+                    checkScore = 0;
+                }
                 // 최고 점수보다 현재 점수가 높을 경우 최고 점수 갱신
                 if (*score > highScore) highScore = *score;
                 RespawnMeteor(&meteors[j], j);
@@ -86,7 +95,7 @@ void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets, int *sco
         }
     }
 
-    // 무적 상태일 경우 충돌 검사 무시
+    // 플레이어 무적 상태일 경우 충돌 검사 무시
     if (playerRef->isCollision) {
         double diffTime = GetTime() - playerRef->deathTime;
         if (diffTime < 2.0) return;  // 아직 무적 상태면 충돌 검사 건너뜀


### PR DESCRIPTION
# 🚀 Pull Request 제목
점수에 따라 운석의 속력 증가 구현 (#27)

## 📌 관련 이슈
Closes #27 

## ✨ 변경 사항 요약
- score가 1000점 증가할 때마다 meteor 속력 0.5씩 증가(meteor.c)

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- MeteorDodgeGamewithShooting/meteor.c

## 📸 스크린샷 / 결과 (옵션)
https://github.com/user-attachments/assets/a57d76c6-aed2-444b-9234-4795182c1ce6

## 🙏 리뷰어에게
- meteor.c 이외에 변경된 파일은 main-복사.c를 삭제하면서 생긴 파일이니 무시하셔도 됩니다.
---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
