### PR TITLE
feat: item에 별 그리는 함수 추가 (#79)

### DIFF
--- a/MeteorDodgeGamewithShooting/item.c
+++ b/MeteorDodgeGamewithShooting/item.c
@@ -57,5 +57,39 @@ void UpdateItem(Item* item, Player* player, bool* meteorFreeze, double* freezeSt
 
 void DrawItem(Item* item) {
     if (!item->active) return;
-    DrawCircleLines((int)item->position.x, (int)item->position.y, ITEM_RADIUS, RED);
+    DrawCircleLines((int)item->position.x, (int)item->position.y, ITEM_RADIUS, BLACK);
+    DrawStar(item->position, ITEM_RADIUS - 1, 5, RED, RED);
+}
+
+
+void DrawStar(Vector2 center, float radius, int points, Color fillColor, Color outlineColor) {
+    if (points < 2) return;
+
+    float angleStep = 2 * PI / (points * 2);
+    Vector2* starVertices = (Vector2*)malloc(sizeof(Vector2) * points * 2);
+    if (!starVertices) return;
+
+    for (int i = 0; i < points * 2; i++) {
+        float r = (i % 2 == 0) ? radius : radius * 0.5f;
+        float angle = i * angleStep - PI / 2;
+        starVertices[i] = (Vector2){
+            center.x + cosf(angle) * r,
+            center.y + sinf(angle) * r
+        };
+    }
+
+    // Fill each star arm as triangle (outer - inner - next outer)
+    for (int i = 0; i < points; i++) {
+        int outer = i * 2;
+        int inner = (outer + 1) % (points * 2);
+        int nextOuter = (outer + 2) % (points * 2);
+        DrawTriangle(starVertices[outer], starVertices[inner], starVertices[nextOuter], fillColor);
+    }
+
+    // Draw outline
+    for (int i = 0; i < points * 2; i++) {
+        DrawLineV(starVertices[i], starVertices[(i + 1) % (points * 2)], outlineColor);
+    }
+
+    free(starVertices);
 }

--- a/MeteorDodgeGamewithShooting/item.c
+++ b/MeteorDodgeGamewithShooting/item.c
@@ -57,7 +57,7 @@ void UpdateItem(Item* item, Player* player, bool* meteorFreeze, double* freezeSt
 
 void DrawItem(Item* item) {
     if (!item->active) return;
-    DrawCircleLines((int)item->position.x, (int)item->position.y, ITEM_RADIUS, BLACK);
+    DrawCircleLines((int)item->position.x, (int)item->position.y, ITEM_RADIUS, Fade(BLACK, 0.0f));
     DrawStar(item->position, ITEM_RADIUS - 1, 5, RED, RED);
 }
 

--- a/MeteorDodgeGamewithShooting/item.h
+++ b/MeteorDodgeGamewithShooting/item.h
@@ -18,3 +18,5 @@ void InitItem(Item* item);
 void UpdateItem(Item* item, Player* player, bool* meteorFreeze, double* freezeStartTime,
     Sound invincibleSound, Sound getItemSound);
 void DrawItem(Item* item);
+
+void DrawStar(Vector2 center, float radius, int points, Color fillColor, Color outlineColor);


### PR DESCRIPTION
# 🚀 Pull Request 제목
item에 별 그리는 함수 추가 (#79)

## 📌 관련 이슈
Closes #79 

## ✨ 변경 사항 요약
- DrawStar 함수 추가
- DrawTriangle이 제대로 구현이 안되고 있어 현재 오각형 안에 별이 있는 형태로 구현됨
- 원래의 원 윤곽선은 투명하게 변경 (기존의 collision 그대로 사용 가능)

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- `item.h`, `item.c`

## 📸 스크린샷 / 결과 (옵션)

![image](https://github.com/user-attachments/assets/f119adc3-0079-4493-a5c9-813681b4444d)


## 🙏 리뷰어에게
- 특정 아이템 등장시에 색상을 변경하여 사용할 예정입니다.
- 두꺼운 윤곽선을 가진 별을 그리는 것도 고려중입니다.

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
