### PR TITLE
fix: 아이템 효과 끝난 후 사운드 효과 중단 (#85)

### DIFF
--- a/MeteorDodgeGamewithShooting/item.c
+++ b/MeteorDodgeGamewithShooting/item.c
@@ -3,6 +3,9 @@
 #include <stdlib.h>
 #include <time.h>
 #include <math.h>
+#include "meteor.h"
+#include "player.h"
+#include "bullet.h"
 
 #define ITEM_RADIUS 15
 #define ITEM_VISIBLE_DURATION 5.0     // 아이템이 유지되는 시간 (초)
@@ -19,7 +22,7 @@ void InitItem(Item* item) {
     for (int i = 0; i < 3; i++) item->itemStartTime[i] = 0;
 }
 
-void UpdateItem(Item* item, Player* player, Sound invincibleSound, Sound getItemSound) {
+void UpdateItem(Item* item, Player* player, Sound invincibleSound, Sound getItemSound, Music gameSceneMusic) {
     double currentTime = GetTime();
 
     //운석 일시정지 아이템
@@ -66,12 +69,16 @@ void UpdateItem(Item* item, Player* player, Sound invincibleSound, Sound getItem
             case STOP_METEOR:
                 item->itemStartTime[0] = currentTime;
                 PlaySound(getItemSound);
+                break;
             case LASER_GUN:
                 item->itemStartTime[1] = currentTime;
                 PlaySound(getItemSound);
+                break;
             case INVINCIBLE_PLAYER:
                 item->itemStartTime[2] = currentTime;
+                StopMusicStream(gameSceneMusic);
                 PlaySound(invincibleSound);
+                break;
             default:
                 break;
             }
@@ -79,6 +86,18 @@ void UpdateItem(Item* item, Player* player, Sound invincibleSound, Sound getItem
             item->isItem = true;
             item->active = false;
             lastInactiveTime = currentTime;
+        }
+    }
+
+    // 플레이어 무적 아이템을 얻은 이후 시간 계산
+    if (!item->active && item->isItem && item->type == INVINCIBLE_PLAYER) {
+        // 5초 지났을 경우 효과음 종료
+        if (currentTime - item->itemStartTime[2] >= INVINCIBLE_TIME) {
+            StopSound(invincibleSound);
+            // 멈춰뒀던 게임 음악 플레이
+            if (!IsMusicStreamPlaying(gameSceneMusic)) {
+                PlayMusicStream(gameSceneMusic);
+            }
         }
     }
 }

--- a/MeteorDodgeGamewithShooting/item.h
+++ b/MeteorDodgeGamewithShooting/item.h
@@ -20,6 +20,6 @@ typedef struct Item {
 } Item;
 
 void InitItem(Item* item);
-void UpdateItem(Item* item, Player* player, Sound invincibleSound, Sound getItemSound);
+void UpdateItem(Item* item, Player* player, Sound invincibleSound, Sound getItemSound, Music gameSceneMusic);
 void DrawItem(Item* item);
 void DrawStar(Vector2 center, float outerRadius, float innerRadius, float rotationAngleDeg, Color color);

--- a/MeteorDodgeGamewithShooting/main.c
+++ b/MeteorDodgeGamewithShooting/main.c
@@ -181,11 +181,10 @@ int main(void)
 
 
             //아이템 업데이트
-            UpdateItem(&item, &player, invincibleSound, getItemSound);
+            UpdateItem(&item, &player, invincibleSound, getItemSound, gameSceneMusic);
 
             //bgm 재생 및 스트리밍
-            if (!IsMusicStreamPlaying(gameSceneMusic)) {
-                StopMusicStream(gameSceneMusic);
+            if (!IsMusicStreamPlaying(gameSceneMusic) && (!item.isItem || item.type != INVINCIBLE_PLAYER)) {
                 PlayMusicStream(gameSceneMusic);
             }
             UpdateMusicStream(gameSceneMusic);


### PR DESCRIPTION
# 🚀 Pull Request 제목
아이템 효과 끝난 후 사운드 효과 중단 (#85)

## 📌 관련 이슈
Closes #85 

## ✨ 변경 사항 요약
- 아이템 사운드 효과 겹치지 않도록 switch 문에 break 걸었습니다.
- 무적 아이템의 경우 player.h의 INVISIBLE_TIME 만큼 사운드 재생 후 종료되도록 변경하였습니다.
- 무적 아이템 효과음 재생 시간동안 기존 게임 배경음악 멈추도록 변경하였습니다. (무적 효과음만 들리게)
- 게임 배경음을 UpdateItem이 매개변수로 받도록 함수를 변경하였기 때문에 pull 시 유의 바랍니다.
- 아이템 획득 사운드가 나고 있는 상황에서, 게임오버가 되거나, 메인화면으로 돌아갔을 때 효과음 재생 안되도록 수정 예정입니다.

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- `item.h`
- `item.c`
- `main.c`

## 📸 스크린샷 / 결과 (옵션)

Uploading Meteor Dodge Game With Shooting 2025-05-27 18-52-19.mp4…


## 🙏 리뷰어에게
- main에서 변경된 부분이 있어 같이 커밋하였습니다. 
- 영상 혹시 소리 안들리시나요?

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
