### PR TITLE
fix: 아이템 생성 화면 제한 (#83)

### DIFF
--- a/MeteorDodgeGamewithShooting/item.c
+++ b/MeteorDodgeGamewithShooting/item.c
@@ -26,7 +26,7 @@ void UpdateItem(Item* item, Player* player, Sound invincibleSound, Sound getItem
     // 아이템이 비활성 상태일 때, 일정 시간이 지나면 다시 생성
     if (!item->active && (currentTime - lastInactiveTime >= ITEM_RESPAWN_DELAY)) {
         item->active = true;
-        item->position = (Vector2){ rand() % SCREEN_WIDTH, rand() % SCREEN_HEIGHT };
+        item->position = (Vector2){ 200 + rand() % 800, 100 + rand() % 600 };
         //아이템 랜덤 생성
         int itemIdx = rand() % 3;
         


### PR DESCRIPTION
# 🚀 Pull Request 제목
아이템 생성 화면 제한 (#83)

## 📌 관련 이슈
Closes #83 

## ✨ 변경 사항 요약
- 아이템이 등장하는 화면 영역을 가로 200-1000, 세로 100-700으로 제한하였습니다.

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- `item.c`

## 📸 스크린샷 / 결과 (옵션)


https://github.com/user-attachments/assets/32d5f0d4-0ea1-4568-93d7-21a70132ca3d


## 🙏 리뷰어에게

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
