### PR TITLE
fix: 아이템 지속 시간 증가 (#87)

### DIFF
--- a/MeteorDodgeGamewithShooting/bullet.c
+++ b/MeteorDodgeGamewithShooting/bullet.c
@@ -12,8 +12,8 @@ void FireBulletOrLaser(Bullet *bullets, Player* playerRef, Item* item, Sound fir
 			bullets[i].active = true;
 			bullets[i].isLaser = playerRef->laserMode;
 
-			bullets[i].isLaser = item->isItem && (item->type == LASER_GUN) && (GetTime() - item->itemStartTime[1] <= 5.0);
-			if (GetTime() - item->itemStartTime[1] > 5.0)
+			bullets[i].isLaser = item->isItem && (item->type == LASER_GUN) && (GetTime() - item->itemStartTime[1] <= LASER_TIME);
+			if (GetTime() - item->itemStartTime[1] > LASER_TIME)
 				item->isItem = false;
 
 			float rad = playerRef->angle * (PI / 180.0f);

--- a/MeteorDodgeGamewithShooting/bullet.h
+++ b/MeteorDodgeGamewithShooting/bullet.h
@@ -13,6 +13,7 @@
 
 #define LASER_SPEED 30
 #define LASER_LENGTH 5
+#define LASER_TIME 5
 
 typedef struct Bullet {
 	Vector2 position;

--- a/MeteorDodgeGamewithShooting/meteor.c
+++ b/MeteorDodgeGamewithShooting/meteor.c
@@ -12,9 +12,9 @@ void RespawnMeteor(Meteor* m, int index) {
 
     // 무작위 색상 저장(밝게)
     m->color = (Color){
-    minBright + rand() % (256 - minBright),
-    minBright + rand() % (256 - minBright),
-    minBright + rand() % (256 - minBright),
+    MIN_BRIGHT + rand() % (256 - MIN_BRIGHT),
+    MIN_BRIGHT + rand() % (256 - MIN_BRIGHT),
+    MIN_BRIGHT + rand() % (256 - MIN_BRIGHT),
     255
     };
 
@@ -63,7 +63,7 @@ void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets, int* sco
     double currentTime = GetTime();
 
   
-    bool freezeActive = item->isItem && (item->type == STOP_METEOR) && (currentTime - item->itemStartTime[0] <= 3.0);
+    bool freezeActive = item->isItem && (item->type == STOP_METEOR) && (currentTime - item->itemStartTime[0] <= STOPMETEOR_TIME);
 
     for (int i = 0; i < MAX_METEORS; i++) {
         if (!freezeActive) {
@@ -123,7 +123,7 @@ void UpdateMeteors(Meteor* meteors, Player* playerRef, Bullet* bullets, int* sco
     // 플레이어 무적 상태일 경우 충돌 검사 무시
     if (playerRef->isCollision) {
         double diffTime = GetTime() - playerRef->deathTime;
-        if (diffTime < 2.0) return;  // 아직 무적 상태면 충돌 검사 건너뜀
+        if (diffTime < INVINCIBLE_TIME) return;  // 아직 무적 상태면 충돌 검사 건너뜀
         else playerRef->isCollision = false;  // 무적 시간 끝났으면 초기화
     }
 

--- a/MeteorDodgeGamewithShooting/meteor.h
+++ b/MeteorDodgeGamewithShooting/meteor.h
@@ -9,7 +9,8 @@
 #include "item.h"
 
 #define MAX_METEORS 40
-#define minBright 100
+#define MIN_BRIGHT 100
+#define STOPMETEOR_TIME 5
 
 extern int highScore;
 

--- a/MeteorDodgeGamewithShooting/player.h
+++ b/MeteorDodgeGamewithShooting/player.h
@@ -5,7 +5,7 @@
 #define PLAYER_FRICTION 0.9f
 #define TRAIL_LENGTH 20
 #define ROTATE_LERP_FACTOR 0.15f
-#define INVINCIBLE_TIME 3
+#define INVINCIBLE_TIME 5
 
 #include "raylib.h"
 #include "raymath.h"


### PR DESCRIPTION
# Pull Request 제목
아이템 지속 시간 증가 (#87)

## 관련 이슈
Closes #87

## 변경 사항 요약
- 각 아이템 지속 시간 define으로 정의하여 헤더파일에 추가(meteor.h, bullet.h)
- 아이템 지속 시간 3초 -> 5초로 변경(meteor.c, bullet.c, player.h)

## 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 변경된 파일
- MeteorDodgeGamewithShooting/bullet.c
- MeteorDodgeGamewithShooting/bullet.h
- MeteorDodgeGamewithShooting/player.h
- MeteorDodgeGamewithShooting/meteor.c
- MeteorDodgeGamewithShooting/meteor.h
(또는 해당 파일들)

## 스크린샷 / 결과 (옵션)
- 레이저 지속시간
https://github.com/user-attachments/assets/557609b2-16c2-4dd5-a9d9-19f06530306e

- 플레이어 무적 지속시간
https://github.com/user-attachments/assets/59c07b81-d521-457b-9e57-e39ead699e9b

- 운석 정지 지속시간
https://github.com/user-attachments/assets/031ec7bb-4817-4560-afe5-ebc5e9283795

## 리뷰어에게

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
