### PR TITLE
아이템 리스폰 딜레이를 아이템 효과가 사라진 시점부터 계산되도록 변경 (#92)

### DIFF
--- a/MeteorDodgeGamewithShooting/item.c
+++ b/MeteorDodgeGamewithShooting/item.c
@@ -9,13 +9,14 @@
 
 #define ITEM_RADIUS 15
 #define ITEM_VISIBLE_DURATION 5.0     // 아이템이 유지되는 시간 (초)
-#define ITEM_RESPAWN_DELAY 10.0       // 아이템이 사라진 후 다시 나타날 때까지의 대기 시간 (초)
+#define ITEM_RESPAWN_DELAY 5.0       // 아이템이 사라진 후 다시 나타날 때까지의 대기 시간 (초)
 
 static double itemActiveTime = 0.0;   // 아이템이 나타난 시점
 static double lastInactiveTime = 0.0; // 아이템이 사라진 시점
 
 void InitItem(Item* item) {
     item->active = false;
+    item->isItem = false;
     item->position = (Vector2){ 0, 0 };
     itemActiveTime = 0;
     lastInactiveTime = GetTime();  // 시작할 때 비활성화로 시작
@@ -25,29 +26,25 @@ void InitItem(Item* item) {
 void UpdateItem(Item* item, Player* player, Sound invincibleSound, Sound getItemSound, Music gameSceneMusic) {
     double currentTime = GetTime();
 
-    //운석 일시정지 아이템
-    // 아이템이 비활성 상태일 때, 일정 시간이 지나면 다시 생성
-    if (!item->active && (currentTime - lastInactiveTime >= ITEM_RESPAWN_DELAY)) {
+    // 아이템이 비활성 상태이고, 아이템 효과도 끝났다면, 일정 시간 이후 다시 생성
+    if (!item->active && !item->isItem && (currentTime - lastInactiveTime >= ITEM_RESPAWN_DELAY)) {
         item->active = true;
         item->position = (Vector2){ 200 + rand() % 800, 100 + rand() % 600 };
         //아이템 랜덤 생성
         int itemIdx = rand() % 3;
-        
-        switch (itemIdx)
-        {
-        case 0:
-            item->type = STOP_METEOR;
+
+        switch (itemIdx) {
+        case 0: 
+            item->type = STOP_METEOR; 
             break;
-        case 1:
-            item->type = LASER_GUN;
+        case 1: 
+            item->type = LASER_GUN; 
             break;
-        case 2:
-            item->type = INVINCIBLE_PLAYER;
-            break;
-        default:
+        case 2: 
+            item->type = INVINCIBLE_PLAYER; 
             break;
         }
-        
+
         itemActiveTime = currentTime;
     }
 
@@ -57,13 +54,12 @@ void UpdateItem(Item* item, Player* player, Sound invincibleSound, Sound getItem
         if (currentTime - itemActiveTime >= ITEM_VISIBLE_DURATION) {
             item->active = false;
             lastInactiveTime = currentTime;
+            item->isItem = false; // 아직 사용 안 했으므로 효과도 없음
             return;
         }
-        lastInactiveTime = currentTime;
 
         // 플레이어가 아이템을 먹었는지 확인
         if (CheckCollisionCircles(player->position, PLAYER_SIZE / 2.0f, item->position, ITEM_RADIUS)) {
-
             switch (item->type)
             {
             case STOP_METEOR:
@@ -82,22 +78,37 @@ void UpdateItem(Item* item, Player* player, Sound invincibleSound, Sound getItem
             default:
                 break;
             }
-            
+
             item->isItem = true;
             item->active = false;
-            lastInactiveTime = currentTime;
         }
     }
 
-    // 플레이어 무적 아이템을 얻은 이후 시간 계산
-    if (!item->active && item->isItem && item->type == INVINCIBLE_PLAYER) {
-        // 5초 지났을 경우 효과음 종료
-        if (currentTime - item->itemStartTime[2] >= INVINCIBLE_TIME) {
+    // 아이템 효과 지속 체크
+    if (item->isItem) {
+
+        // 플레이어 무적 아이템을 얻은 이후 시간 계산
+        if (item->type == INVINCIBLE_PLAYER && currentTime - item->itemStartTime[2] >= INVINCIBLE_TIME) {
+            // 5초 지났을 경우 효과음 종료
             StopSound(invincibleSound);
             // 멈춰뒀던 게임 음악 플레이
             if (!IsMusicStreamPlaying(gameSceneMusic)) {
                 PlayMusicStream(gameSceneMusic);
             }
+            item->isItem = false;
+            lastInactiveTime = currentTime; // 아이템 효과가 끝났으므로, 여기서부터 respawn 시간 카운트
+        }
+
+        // 운석 정지 아이템 체크
+        if (item->type == STOP_METEOR && currentTime - item->itemStartTime[0] >= STOPMETEOR_TIME) {
+            item->isItem = false;
+            lastInactiveTime = currentTime;
+        }
+
+        // 레이저 아이템 체크
+        if (item->type == LASER_GUN && currentTime - item->itemStartTime[1] >= LASER_TIME) {
+            item->isItem = false;
+            lastInactiveTime = currentTime;
         }
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request 제목
아이템 리스폰 딜레이를 아이템 효과가 사라진 시점부터 계산되도록 변경 (#92)

## 📌 관련 이슈
Closes #92 

## ✨ 변경 사항 요약
- ITEM_RESPAWN_DELAY = 10 에서 5로 수정(item.c)
- ITEM_RESPAWN_DELAY를 아이템 효과가 사라진 시점부터 계산하도록 코드 수정(item.c)

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- MeteorDodgeGamewithShooting/item.c

## 📸 스크린샷 / 결과 (옵션)
https://github.com/user-attachments/assets/6fb1bd04-6ba4-45c5-82b2-3c5517190750

## 🙏 리뷰어에게
- 플레이 중에 아이템(레이저 제외)이 적용되는 도중에 총알을 발사하면 아이템 적용이 풀리고 새로운 아이템이 화면에 생성되는 버그를 발견하였습니다. bullet.c에서 생긴 문제로 추측됩니다. Issue 작성 부탁드립니다.
- 영상에 다 안 담긴 부분이 있으니 직접 플레이하면서 체크하시길 권장드립니다.

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
