### PR TITLE
fix: 아이템 획득 후 총알 발사 시 아이템 효과가 강제 종료되는 문제 해결 (#96)

### DIFF
--- a/MeteorDodgeGamewithShooting/bullet.c
+++ b/MeteorDodgeGamewithShooting/bullet.c
@@ -13,8 +13,6 @@ void FireBulletOrLaser(Bullet *bullets, Player* playerRef, Item* item, Sound fir
 			bullets[i].isLaser = playerRef->laserMode;
 
 			bullets[i].isLaser = item->isItem && (item->type == LASER_GUN) && (GetTime() - item->itemStartTime[1] <= LASER_TIME);
-			if (GetTime() - item->itemStartTime[1] > LASER_TIME)
-				item->isItem = false;
 
 			float rad = playerRef->angle * (PI / 180.0f);
 


### PR DESCRIPTION
# 🚀 Pull Request 제목
fix: 아이템 획득 후 총알 발사 시 아이템 효과가 강제 종료되는 문제 해결 (#96)

## 📌 관련 이슈
Closes #96 

## ✨ 변경 사항 요약
- isItem을 false로 만드는 부분 삭제

## 🧪 테스트 방법
- [ ] 빌드가 정상적으로 되는지 확인
- [ ] 해당 기능이 예상대로 동작하는지 확인
- [ ] 기존 기능이 영향을 받지 않는지 확인

## 📂 변경된 파일
- bullet.c

## 📸 스크린샷 / 결과 (옵션)

## 🙏 리뷰어에게
- 레이저 건 아이템이 아닌 다른 아이템 획득의 경우, 총알을 발사할 때마다 isItem을 false로 만드는 조건에 걸렸기 때문에 아이템 효과가 강제 종료되었음

---

_이 PR은 기능 단위로 잘게 나뉜 작업 중 하나입니다. main/dev 브랜치에 병합 후, 관련 이슈는 자동으로 종료됩니다._
